### PR TITLE
[thread_safe_store] implement faster Index()

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/index.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // Indexer extends Store with multiple indices and restricts each
@@ -91,8 +90,12 @@ func MetaNamespaceIndexFunc(obj interface{}) ([]string, error) {
 	return []string{meta.GetNamespace()}, nil
 }
 
+type Object struct {
+	obj interface{}
+}
+
 // Index maps the indexed value to a set of keys in the store that match on that value
-type Index map[string]sets.String
+type Index map[string]map[string]*Object
 
 // Indexers maps a name to an IndexFunc
 type Indexers map[string]IndexFunc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
In our environment we have a namespace with ~3k deployments and ~10k pods in it.
Most of the deployments are updated simultaneously. We observed that during this mass-rollout time kube-controller manager in some situations starts to consume 100+GB of memory and  significant amount of CPU. 
Collected cpu and memory profiles (attached) 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

benchstats diff for `go test -run=NONE -bench=BenchmarkIndexerIndex -benchmem` for old/new implementations. 

```


goos: darwin
goarch: arm64
pkg: k8s.io/client-go/tools/cache
                │     old     │                index                │
                │   sec/op    │   sec/op     vs base                │
IndexerIndex-10   478.9µ ± 3%   154.2µ ± 1%  -67.80% (p=0.000 n=10)

                │     old      │                index                │
                │     B/op     │     B/op      vs base               │
IndexerIndex-10   160.2Ki ± 0%   160.2Ki ± 0%  +0.00% (p=0.000 n=10)

                │    old     │             index              │
                │ allocs/op  │ allocs/op   vs base            │
IndexerIndex-10   5.000 ± 0%   5.000 ± 0%  ~ (p=1.000 n=10) ¹
```
![cpu profile](https://user-images.githubusercontent.com/6113489/229979393-407f4fe2-d465-4bbb-bde2-e25a70d6aac3.svg) ![memory profile](https://user-images.githubusercontent.com/6113489/229980530-dc3396a5-02fc-446a-8b34-4aa3a3d16659.svg)

